### PR TITLE
Add MIT LICENSE and docs updates for Jan Suraksha #55

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jan Suraksha contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
<img width="1287" height="633" alt="image" src="https://github.com/user-attachments/assets/1960d8bf-8b56-427c-a93b-7072f0231436" />



Closes: #55 

**Description**  
- Add MIT `LICENSE` file at the repository root so users and institutions have clear legal terms to use, modify, and deploy the Jan Suraksha crime reporting portal.[1][2]
- Update `README.md` with a “License” section: `This project is licensed under the MIT License – see the LICENSE file for details.`[3][1]
- (Optional) Add a line in `CONTRIBUTING.md` that all contributions are accepted under the MIT License.[1]

**Checklist**  
- [x] Added MIT `LICENSE` file at root  
- [x] Updated `README.md` with License section  
- [x] Updated `CONTRIBUTING.md` to mention MIT
