### PR TITLE
Security: Fix SQL Injection Vulnerability in Admin Dashboard Queries

### DIFF
--- a/jan_suraksha/admin/update-case.php
+++ b/jan_suraksha/admin/update-case.php
@@ -99,7 +99,12 @@ $case = $stmt->get_result()->fetch_assoc();
 
 if (!$case) { die("Error: Case not found."); }
 
-$diary_entries = $mysqli->query("SELECT * FROM case_diary WHERE complaint_id = $complaint_id ORDER BY created_at DESC");
+// Fetch diary entries using prepared statement to prevent SQL injection
+$stmt = $mysqli->prepare("SELECT * FROM case_diary WHERE complaint_id = ? ORDER BY created_at DESC");
+$complaint_id_int = (int)$complaint_id;
+$stmt->bind_param('i', $complaint_id_int);
+$stmt->execute();
+$diary_entries = $stmt->get_result();
 
 $current_page = 'cases.php'; // CORRECTED
 ?>


### PR DESCRIPTION
##  Security Fix: SQL Injection Prevention

Fixes #93

### Summary
Replaced all direct SQL queries with prepared statements in admin dashboard files to prevent SQL injection attacks.

### Changes Made
-  **admin/dashboard.php** - 8 queries converted to prepared statements
- **admin/criminals.php** - 2 queries converted to prepared statements  
- **admin/update-case.php** - 1 query converted to prepared statement

### Security Improvements
- All user inputs now properly parameterized using `mysqli_prepare()` and `bind_param()`
- Eliminated string concatenation in SQL queries
- Added proper type binding ('i' for integers, 's' for strings)
- Better error handling with server-side logging

### Testing
- [x] Admin dashboard metrics display correctly
- [x] Crime category breakdown works
- [x] Recent complaints table shows data
- [x] Criminals pagination functions properly
- [x] Case diary entries load correctly
- [x] No SQL syntax errors

### References
- OWASP SQL Injection Prevention: https://owasp.org/www-community/attacks/SQL_Injection
- Issue #93: SQL Injection Vulnerability in Admin Dashboard Queries