### PR TITLE
Fix: Restrict mobile number input to 10 digits

### DIFF
--- a/jan_suraksha/register.php
+++ b/jan_suraksha/register.php
@@ -249,7 +249,7 @@ body {
 
             <div class="mb-3">
               <label class="form-label">Mobile Number</label>
-              <input class="form-control" name="mobile" type="tel" autocomplete="tel" placeholder="10 digit mobile number" required>
+              <input class="form-control" name="mobile" type="tel" autocomplete="tel" maxlength="10" placeholder="10 digit mobile number" required>
               <div class="invalid-feedback">Enter a valid 10 digit mobile number.</div>
             </div>
 


### PR DESCRIPTION
This PR fixes an issue where the mobile number input field on the registration page
allowed more than 10 digits.

Change made:
- Added maxlength="10" to the mobile number input field in register.php
<img width="470" height="778" alt="image" src="https://github.com/user-attachments/assets/05c491f9-851a-447e-8104-357ccaa91ff8" />
